### PR TITLE
Mint: add test scripts in package.json file to fix error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\" && exit 0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
Adding the test scripts to make the GitHub action run pass the frontend test because there still no test for frontend.